### PR TITLE
monkey-patch Kemal issue

### DIFF
--- a/src/ext/kemal.cr
+++ b/src/ext/kemal.cr
@@ -14,3 +14,13 @@ end
 macro render(filename)
   Kilt.render({{filename}})
 end
+
+module Kemal
+  # :nodoc:
+  class FilterHandler
+    # FIXME: https://github.com/kemalcr/kemal/pull/564
+    private def radix_path(verb : String?, path : String, type : Symbol)
+      "/#{type}/#{verb.upcase}/#{path}"
+    end
+  end
+end


### PR DESCRIPTION
https://shards.info site is not affected by this security breach because we use only before_all macros which are not affected by this Kemal issue (https://github.com/kemalcr/kemal/pull/564)

and nginx doen't allow lowercase HTTP methods

```
curl -X DELETE https://shards.info/admin/users/1
Forbidden
```

```
curl -X delete https://shards.info/admin/users/1

<html>
<head><title>400 Bad Request</title></head>
<body>
<center><h1>400 Bad Request</h1></center>
<hr><center>nginx</center>
</body>
</html>
```