### PR TITLE
Specifies mosquito version 2.0 in shards.yml

### DIFF
--- a/shard.yml
+++ b/shard.yml
@@ -22,7 +22,7 @@ dependencies:
     github: jgaskins/redis
   mosquito:
     github: mosquito-cr/mosquito
-    branch: master
+    version: "~> 2.0"
   kemal-session:
     github: kemalcr/kemal-session
   kemal-session-redis-engine:


### PR DESCRIPTION
The changes you needed from the master branch are now part of the 2.0 release, so tracking master is no longer _necessary_. Feel free to disregard if you'd prefer to continue to track master! 🍰